### PR TITLE
Add MessageDigestAlgorithms pattern for SHA_1 and MD5

### DIFF
--- a/security/weak-hash-function-md5.yml
+++ b/security/weak-hash-function-md5.yml
@@ -9,4 +9,8 @@
       - vulnerability
   patterns-either:
     - pattern: (MessageDigest/getInstance "MD5")
+    - pattern: (MessageDigest/getInstance MessageDigestAlgorithms/MD5)
+    - pattern: (MessageDigest/getInstance org.apache.commons.codec.digest.MessageDigestAlgorithms/MD5)
     - pattern: (java.security.MessageDigest/getInstance "MD5")
+    - pattern: (java.security.MessageDigest/getInstance MessageDigestAlgorithms/MD5)
+    - pattern: (java.security.MessageDigest/getInstance org.apache.commons.codec.digest.MessageDigestAlgorithms/MD5)

--- a/security/weak-hash-function-sha1.yml
+++ b/security/weak-hash-function-sha1.yml
@@ -9,4 +9,8 @@
       - vulnerability
   patterns-either:
     - pattern: (MessageDigest/getInstance "SHA1")
+    - pattern: (MessageDigest/getInstance org.apache.commons.codec.digest.MessageDigestAlgorithms/SHA_1)
+    - pattern: (MessageDigest/getInstance MessageDigestAlgorithms/SHA_1)
     - pattern: (java.security.MessageDigest/getInstance "SHA1")
+    - pattern: (java.security.MessageDigest/getInstance org.apache.commons.codec.digest.MessageDigestAlgorithms/SHA_1)
+    - pattern: (java.security.MessageDigest/getInstance MessageDigestAlgorithms/SHA_1)


### PR DESCRIPTION
## Context
Add MessageDigestAlgorithms pattern for SHA_1 and MD5, that way people using https://commons.apache.org/proper/commons-codec/apidocs/org/apache/commons/codec/digest/MessageDigestAlgorithms.html#MD5 are also covered.